### PR TITLE
Refactor Injector classes

### DIFF
--- a/demo/01_basics.py
+++ b/demo/01_basics.py
@@ -268,7 +268,7 @@ def __():
 
 @app.cell
 def __(torch):
-    machine = "cpu"  # Pick "cuda" for a Nvidia GPU machine
+    machine = "cpu"  # Pick "cuda" for a machine with an Nvidia GPU
     dtype = torch.float32
     return dtype, machine
 
@@ -284,13 +284,8 @@ def __(ADMMSolver, admm_devices, dtype, machine, net, time_horizon):
     admm = ADMMSolver(
         machine=machine,
         dtype=dtype,
-        num_iterations=10000,
-        rho_power=1.0,
-        rho_angle=1.0,
         atol=1e-6,
         rtol=1e-6,
-        adaptive_rho=True,
-        adaptation_frequency=50,
     )
 
     solution_admm, history_admm = admm.solve(net, admm_devices, time_horizon)

--- a/demo/01_basics.py
+++ b/demo/01_basics.py
@@ -294,6 +294,12 @@ def __(ADMMSolver, admm_devices, dtype, machine, net, time_horizon):
 
 @app.cell
 def __(solution_admm):
+    solution_admm.power
+    return
+
+
+@app.cell
+def __(solution_admm):
     # ADMM solutions need to be cast to a standard DispatchOutcome
     outcome_admm = solution_admm.as_outcome()
 

--- a/development/_test_injector.py
+++ b/development/_test_injector.py
@@ -1,0 +1,73 @@
+import marimo
+
+__generated_with = "0.9.14"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def __():
+    import marimo as mo
+    import numpy as np
+    import zap
+    return mo, np, zap
+
+
+@app.cell
+def __(zap):
+    net = zap.PowerNetwork(num_nodes=5)
+    return (net,)
+
+
+@app.cell
+def __(net, np, zap):
+    injector = zap.Injector(
+        num_nodes=net.num_nodes,
+        terminal=np.array([0]),
+        nominal_capacity=np.array([1.0]),
+        min_power=np.array([[10.0, 15.0, 20.0]]),
+        max_power=np.array([[10.0, 15.0, 20.0]]),
+        linear_cost=np.array([500.0]),
+    )
+    injector
+    return (injector,)
+
+
+@app.cell
+def __(net, np, zap):
+    load = zap.Load(
+        num_nodes=net.num_nodes,
+        terminal=np.array([0]),
+        load=np.array([[10.0, 15.0, 20.0]]),
+        linear_cost=np.array([500.0]),
+    )
+    load
+    return (load,)
+
+
+@app.cell
+def __(net, np, zap):
+    generators = zap.Generator(
+        num_nodes=net.num_nodes,
+        terminal=np.array([1, 2]),
+        nominal_capacity=np.array([50.0, 25.0]),
+        linear_cost=np.array([0.1, 30.0]),
+        emission_rates=np.array([0.0, 500.0]),
+        dynamic_capacity=np.array(
+            [
+                [0.1, 0.5, 0.1],
+                [1.0, 1.0, 1.0],
+            ]
+        ),
+    )
+    generators
+    return (generators,)
+
+
+@app.cell
+def __(generators):
+    generators.min_power
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/poetry.lock
+++ b/poetry.lock
@@ -3591,4 +3591,4 @@ pypsa = ["pypsa"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.13"
-content-hash = "1922ad23681d3be3b25bd285377f1eefd6ce196b39ce79bc36e000ce162011c1"
+content-hash = "5d363012bfd1d4c91eb5a6bf1dfe9058fc6ba7c01f35bfb4f89723f0a3cc08da"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ scipy = "^1.12.0"
 torch = "~2.2.0"
 pypsa = {version = "^0.27.0", optional = true}
 sparse-dot-mkl = {version = "^0.9.6", optional = true}
+attrs = "^24.2.0"
 
 [tool.poetry.extras]
 pypsa = ["pypsa"]

--- a/zap/admm/basic_solver.py
+++ b/zap/admm/basic_solver.py
@@ -89,16 +89,18 @@ class ADMMState:
         )
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass()
 class ADMMSolver:
     """Stores ADMM solver parameters and exposes a solve function."""
 
-    num_iterations: int
-    rho_power: float
-    rho_angle: Optional[float] = None
+    machine: str = None
+    dtype: object = torch.float32
+    num_iterations: int = 10000
+    rho_power: float = 1.0
+    rho_angle: Optional[float] = 1.0
     alpha: float = 1.0
-    atol: float = 0.0
-    rtol: float = 0.0
+    atol: float = 1e-5
+    rtol: float = 1e-5
     rtol_primal: Optional[float] = None
     rtol_dual: Optional[float] = None
     dual_bias: float = 1.0
@@ -106,20 +108,17 @@ class ADMMSolver:
     resid_norm: int = 2
     safe_mode: bool = False
     track_objective: bool = True
-    machine: str = None
-    dtype: object = torch.float64
     battery_window: Optional[int] = None
     battery_inner_weight: float = 1.0
     battery_inner_over_relaxation: float = 1.8
     battery_inner_iterations: int = 10
     minimum_iterations: int = 10
     relative_rho_angle: bool = False
-    adaptive_rho: bool = False
+    adaptive_rho: bool = True
     tau: float = 1.1
     adaptation_tolerance: float = 2.0
-    adaptation_frequency: int = 10
+    adaptation_frequency: int = 50
     verbose: int = 1
-
     scale_dual_residuals: bool = None  # Deprecated
 
     def __post_init__(self):

--- a/zap/devices/abstract.py
+++ b/zap/devices/abstract.py
@@ -1,4 +1,5 @@
 import torch
+import warnings
 import cvxpy as cp
 import numpy as np
 import scipy.sparse as sp
@@ -257,6 +258,9 @@ class AbstractDevice:
 
         if machine == "cuda":
             print(f"Warning: moving data to GPU for device {type(self)}")
+
+        if hasattr(new_device, "__slots__"):
+            warnings.warn("torchify does not support __slots__ for device classes. ")
 
         for k, v in new_device.__dict__.items():
             if isinstance(v, np.ndarray) and np.issubdtype(v.dtype, np.number):

--- a/zap/devices/injector.py
+++ b/zap/devices/injector.py
@@ -12,7 +12,7 @@ from .abstract import AbstractDevice, get_time_horizon, make_dynamic
 @define(kw_only=True, slots=False)
 class AbstractInjector(AbstractDevice):
     """A single-node device that may deposit or withdraw power from the network. Abstract type that
-    should not be instantiated."""
+    should not be instantiated but contains shared behavior among all subclasses."""
 
     num_nodes: int
     terminal: NDArray
@@ -28,10 +28,6 @@ class AbstractInjector(AbstractDevice):
     quadratic_cost: Optional[NDArray] = field(init=False)
     capital_cost: Optional[NDArray] = field(init=False)
     emission_rates: Optional[NDArray] = field(init=False)
-
-    # ====
-    # SHARED BEHAVIOR
-    # ====
 
     @property
     def terminals(self):


### PR DESCRIPTION
This PR refactors `Injector`, `Generator`, and `Load` to jointly inherit `AbstractInjector` and switches from `dataclasses` to `attrs`.

Additional Minor Changes
- Change ADMM default arguments to reasonable defaults
- [Bugfix] Scale prices by rho when converting ADMM state to dispatch outcome