### PR TITLE
Parametrize SOC and differentiate Store

### DIFF
--- a/zap/devices/store.py
+++ b/zap/devices/store.py
@@ -1,4 +1,3 @@
-import torch
 import numpy as np
 import cvxpy as cp
 import scipy.sparse as sp
@@ -40,7 +39,7 @@ class Store(AbstractDevice):
             storage_efficiency = np.ones(nominal_energy_capacity.shape)
 
         if min_energy_capacity_availability is None:
-            min_energy_capacity_availability = np.ones(nominal_energy_capacity.shape)
+            min_energy_capacity_availability = np.zeros(nominal_energy_capacity.shape)
 
         if max_energy_capacity_availability is None:
             max_energy_capacity_availability = np.ones(nominal_energy_capacity.shape)
@@ -120,23 +119,41 @@ class Store(AbstractDevice):
         return [cp.Variable((self.num_devices, time_horizon + 1))]
 
     def equality_constraints(
-        self, power, angle, SOC, nominal_energy_capacity=None, la=np, envelope=None
+        self,
+        power,
+        angle,
+        SOC,
+        nominal_energy_capacity=None,
+        initial_soc=None,
+        final_soc=None,
+        la=np,
+        envelope=None,
     ):
         SOC = SOC[0]
         nominal_energy_capacity = self.parameterize(
             nominal_energy_capacity=nominal_energy_capacity, la=la
         )
+        initial_soc = self.parameterize(initial_soc=initial_soc, la=la)
+        final_soc = self.parameterize(final_soc=final_soc, la=la)
 
         T = power[0].shape[1]
 
         return [  # eq 0
             SOC[:, 1:] - SOC[:, :-1] + power[0],
-            SOC[:, 0:1] - la.multiply(self.initial_soc, nominal_energy_capacity),
-            SOC[:, T : (T + 1)] - la.multiply(self.final_soc, nominal_energy_capacity),
+            SOC[:, 0:1] - la.multiply(initial_soc, nominal_energy_capacity),
+            SOC[:, T : (T + 1)] - la.multiply(final_soc, nominal_energy_capacity),
         ]
 
     def inequality_constraints(
-        self, _1, _2, SOC, nominal_energy_capacity=None, la=np, envelope=None
+        self,
+        _1,
+        _2,
+        SOC,
+        nominal_energy_capacity=None,
+        initial_soc=None,
+        final_soc=None,
+        la=np,
+        envelope=None,
     ):
         SOC = SOC[0]
         nominal_energy_capacity = self.parameterize(
@@ -156,12 +173,22 @@ class Store(AbstractDevice):
         ]
 
     def operation_cost(
-        self, power, _, state, power_capacity=None, la=np, envelope=None
+        self,
+        power,
+        _,
+        state,
+        nominal_energy_capacity=None,
+        initial_soc=None,
+        final_soc=None,
+        la=np,
+        envelope=None,
     ):
         if state is None:
             return 0.0
 
         cost = la.sum(la.multiply(self.linear_cost, power[0]))
+        cost += la.sum(la.multiply(self.linear_storage_cost, state.discharge))
+
         if self.quadratic_cost is not None:
             cost += la.sum(la.multiply(self.quadratic_cost, la.square(power[0])))
 
@@ -202,7 +229,15 @@ class Store(AbstractDevice):
 
         return sp.coo_matrix((values, (rows, cols)), shape=shape)
 
-    def _equality_matrices(self, equalities, power_capacity=None, la=np):
+    def _equality_matrices(
+        self,
+        equalities,
+        nominal_energy_capacity=None,
+        initial_soc=None,
+        final_soc=None,
+        la=np,
+    ):
+        raise NotImplementedError("Please update from StorageUnit to Store.")
         # Dimensions
         size = equalities[0].power[0].shape[1]
         time_horizon = int(size / self.num_devices)
@@ -231,7 +266,15 @@ class Store(AbstractDevice):
 
         return equalities
 
-    def _inequality_matrices(self, inequalities, power_capacity=None, la=np):
+    def _inequality_matrices(
+        self,
+        inequalities,
+        nominal_energy_capacity=None,
+        initial_soc=None,
+        final_soc=None,
+        la=np,
+    ):
+        raise NotImplementedError("Please update from StorageUnit to Store.")
         size = inequalities[0].power[0].shape[1]
         e_size = inequalities[0].local_variables[0].shape[0]
 
@@ -245,8 +288,17 @@ class Store(AbstractDevice):
         return inequalities
 
     def _hessian_local_variables(
-        self, hessians, power, angle, state, power_capacity=None, la=np
+        self,
+        hessians,
+        power,
+        angle,
+        state,
+        nominal_energy_capacity=None,
+        initial_soc=None,
+        final_soc=None,
+        la=np,
     ):
+        raise NotImplementedError("Please update from StorageUnit to Store.")
         if self.quadratic_cost is None:
             return hessians
 
@@ -257,257 +309,20 @@ class Store(AbstractDevice):
     # PLANNING FUNCTIONS
     # ====
 
-    def get_investment_cost(self, power_capacity=None, la=np):
-        power_capacity = self.parameterize(power_capacity=power_capacity, la=la)
+    def get_investment_cost(
+        self, nominal_energy_capacity=None, initial_soc=None, final_soc=None, la=np
+    ):
+        raise NotImplementedError("Please update from StorageUnit to Store.")
+        nominal_energy_capacity = self.parameterize(
+            nominal_energy_capacity=nominal_energy_capacity, la=la
+        )
 
-        if self.capital_cost is None or power_capacity is None:
+        if self.capital_cost is None or nominal_energy_capacity is None:
             return 0.0
 
         # Get original nominal capacity and capital cost
         # Nominal capacity isn't passed here because we want to use the original value
-        pnom_min = self.power_capacity
+        pnom_min = self.nominal_energy_capacity
         capital_cost = self.capital_cost
 
-        return la.sum(la.multiply(capital_cost, (power_capacity - pnom_min)))
-
-    # ====
-    # ADMM FUNCTIONS
-    # ====
-    def admm_prox_update(
-        self,
-        rho_power,
-        rho_angle,
-        power,
-        angle,
-        power_capacity=None,
-        power_weights=None,
-        angle_weights=None,
-        window=None,
-        inner_weight=1.0,
-        inner_over_relaxation=1.0,
-        inner_iterations=25,
-    ):
-        inner_weight = rho_power * inner_weight
-
-        power_capacity = self.parameterize(power_capacity=power_capacity)
-        N, full_time_horizon = power[0].shape
-        T = full_time_horizon if window is None else window  # Window size
-        num_scenarios = full_time_horizon // T
-
-        machine, dtype = power[0].device, power[0].dtype
-
-        assert angle is None
-        assert full_time_horizon % T == 0
-
-        # Fixed data - constant between solves
-        # Update: not constant if rho or inner_weight changes
-        # So we update this once per solve
-        # if not hasattr(self, "admm_data"):
-        #     self.admm_data = battery_prox_data(self, T, rho_power, power[0], inner_weight)
-
-        # Variable data that changes between solves
-        if self.has_changed:
-            # print("Changing battery data.")
-
-            smax = torch.multiply(power_capacity, self.duration)
-            gamma1 = torch.multiply(self.initial_soc, smax)
-            gammaT = torch.multiply(self.final_soc, smax)
-            ymin, ymax = get_ymin_ymax(
-                T, power_capacity, smax, gamma1, gammaT, machine, dtype
-            )
-            A = A_matrix(T, machine, dtype=dtype)
-            b = b_vector(self, T, machine)
-
-            _zT = power[0].reshape(-1, num_scenarios, T, 1)
-            _rhs = K_rhs_fixed(rho_power, A, b, _zT)
-            zero_nu = torch.zeros(
-                (_rhs.shape[0], _rhs.shape[1], T, _rhs.shape[3]),
-                device=machine,
-                dtype=dtype,
-            )
-
-            self.temp_data = (smax, gamma1, gammaT, ymin, ymax, A, b, zero_nu)
-
-        if self.has_changed or self.rho != rho_power:
-            # print("Updating battery Schur matrix.")
-            self.rho = rho_power
-            self.schur = schur_matrix(self, T, rho_power, inner_weight, machine)
-            # _K = K_matrix(self, T, rho_power, inner_weight, machine)
-            # self.K_inv = torch.linalg.inv(_K)
-
-        self.has_changed = False
-
-        # schur = self.schur
-        # K_inv = self.K_inv
-        schur = self.schur
-        smax, gamma1, gammaT, ymin, ymax, A, b, zero_nu = self.temp_data
-
-        # Changes every proximal evaluation
-        zT = power[0].reshape(-1, num_scenarios, T, 1)
-        rhs = K_rhs_fixed(rho_power, A, b, zT)
-
-        # Initialize
-        x = torch.zeros((N, num_scenarios, 3 * T + 1, 1), device=machine, dtype=dtype)
-        y = torch.zeros(x.shape, device=machine, dtype=dtype)
-        u = torch.zeros(x.shape, device=machine, dtype=dtype)
-
-        y[:, :, :T, :] = torch.relu(-zT)
-        y[:, :, T : (2 * T), :] = torch.relu(zT)
-        y[:, :, (2 * T) :, :] = gamma1.reshape(-1, 1, 1, 1)
-
-        # Solve ADMM
-        for iter in range(inner_iterations):
-            x, y, u = battery_prox_inner(
-                x, y, u, rhs, schur, ymin, ymax, inner_weight, inner_over_relaxation
-            )
-
-        # Extract results
-        c = x[:, :, :T, 0].reshape(N, -1)
-        d = x[:, :, T : (2 * T), 0].reshape(N, -1)
-        # s = x[:, :, (2 * T) :, 0].reshape(N, -1)
-
-        return [d - c], None
-
-
-# ====
-# ADMM UTILITY FUNCTIONS
-# ====
-
-
-def difference_matrix(T, machine=None, dtype=None):
-    # Should return a (T, T+1) matrix where
-    # D = [-1 1 0 0]
-    #     [0 -1 1 0]
-    #     [0 0 -1 1]
-    # for T = 3
-
-    D1 = torch.eye(T + 1, device=machine, dtype=dtype)[0:T, :]
-    D2 = torch.eye(T + 1, device=machine, dtype=dtype)[1:, :]
-
-    return D2 - D1
-
-
-def b_vector(device: Store, T, machine=None):
-    dtype = device.power_capacity.dtype
-
-    # TODO - Support multiple costs
-    alpha = device.linear_cost[0]
-    return torch.vstack(
-        [
-            alpha * torch.ones((T, 1), device=machine, dtype=dtype),
-            torch.zeros((2 * T + 1, 1), device=machine, dtype=dtype),
-        ]
-    )
-
-
-def C_matrix(device: Store, T, machine=None, dtype=None):
-    # TODO - Support multiple charge efficiencies
-    beta = device.charge_efficiency[0]
-    D = difference_matrix(T, machine, dtype)
-    Id = torch.eye(T, device=machine, dtype=dtype)
-
-    return torch.hstack([-beta * Id, Id, D])
-
-
-def A_matrix(T, machine=None, dtype=None):
-    Id = torch.eye(T, device=machine)
-    return torch.hstack([-Id, Id, torch.zeros(T, T + 1, device=machine, dtype=dtype)])
-
-
-def K_matrix(device: Store, T, rho, w, machine=None):
-    dtype = device.power_capacity.dtype
-
-    A = A_matrix(T, machine, dtype)
-    C = C_matrix(device, T, machine, dtype)
-    Id = torch.eye(3 * T + 1, device=machine, dtype=dtype)
-
-    dKdx = rho * (A.T @ A) + w * Id
-    if device.quadratic_cost is not None:
-        dKdx[2 * T + 1 :, 2 * T + 1 :] += torch.diag(device.quadratic_cost)
-
-    row1 = torch.hstack([dKdx, C.T])
-    row2 = torch.hstack([C, torch.zeros(T, T, device=machine)])
-
-    return torch.vstack([row1, row2])
-
-
-def schur_matrix(device, T, rho, w, machine=None):
-    dtype = device.power_capacity.dtype
-
-    A = A_matrix(T, machine, dtype)
-    C = C_matrix(device, T, machine, dtype)
-    Id = torch.eye(3 * T + 1, device=machine, dtype=dtype)
-
-    # Hessian
-    H = rho * (A.T @ A) + w * Id
-    if device.quadratic_cost is not None:
-        H[2 * T + 1 :, 2 * T + 1 :] += torch.diag(device.quadratic_cost)
-
-    H_inv = torch.linalg.inv(H)
-
-    # Reduced terms
-    Q = C @ H_inv
-    M = Q @ C.T
-
-    # Return Schur complement
-    return H_inv - Q.T @ torch.linalg.inv(M) @ Q
-
-
-def K_rhs_fixed(rho, A, b, z):
-    # rho * A.T @ z - b
-    return rho * torch.matmul(A.T, z) - b
-
-
-@torch.jit.script
-def battery_prox_inner(x, y, u, rhs, schur, ymin, ymax, w: float, alpha: float = 1.0):
-    # x update
-    rhs_var = rhs + w * (y - u)
-
-    # full_rhs = torch.cat([rhs_var, zero_nu], dim=2)
-    # x = (K_inv @ full_rhs)[:, :, : x.shape[2], :]
-    x = schur @ rhs_var
-
-    # over relaxation step
-    xp = alpha * x + (1 - alpha) * y
-
-    # y update
-    y = torch.clip(xp + u, min=ymin, max=ymax)
-
-    # u update
-    u += xp - y
-
-    return x, y, u
-
-
-def battery_prox_data(device: Store, T: int, rho, z, weight=1.0):
-    machine = z.device
-
-    T_full = z.shape[1]
-    num_scenarios = T_full // T
-    assert T * num_scenarios == T_full
-
-    # Fixed data that does not change between solves
-    K = K_matrix(device, T, rho, weight, machine)
-    K_inv = torch.linalg.inv(K)
-
-    # zT and rhs are just created to get the dimensions for zero_nu
-    zT = z.reshape(-1, num_scenarios, T, 1)
-    rhs = K_rhs_fixed(rho, A_matrix(T, machine), b_vector(device, T, machine), zT)
-    zero_nu = torch.zeros((rhs.shape[0], rhs.shape[1], T, rhs.shape[3]), device=machine)
-
-    return K_inv, zero_nu
-
-
-def get_ymin_ymax(T, pmax, smax, gamma1, gammaT, machine=None, dtype=None):
-    ymax = torch.hstack([pmax.expand(-1, 2 * T), smax.expand(-1, T + 1)])
-    ymin = torch.zeros(ymax.shape, device=machine, dtype=dtype)
-
-    ymin[:, 2 * T] = gamma1[:, 0]
-    ymax[:, 2 * T] = gamma1[:, 0]
-    ymin[:, -1] = gammaT[:, 0]
-    ymax[:, -1] = gammaT[:, 0]
-
-    ymin = ymin.reshape(ymin.shape[0], 1, ymin.shape[1], 1)
-    ymax = ymax.reshape(ymax.shape[0], 1, ymax.shape[1], 1)
-
-    return ymin, ymax
+        return la.sum(la.multiply(capital_cost, (nominal_energy_capacity - pnom_min)))


### PR DESCRIPTION
Note: the target for this PR is `kt/pypsa` (not `main`).

- Allow `initial_soc` and `final_soc` to be parameters for `Store` and `StorageUnit`.
- Support differentiation for `Store`

No tests yet... next step will be a Marimo notebook testing these features incrementally.