### PR TITLE
Add support for Second Order Cone Slack Devices

### DIFF
--- a/cone_tests/soc_debugger_test.py
+++ b/cone_tests/soc_debugger_test.py
@@ -1,0 +1,52 @@
+from zap.conic.cone_bridge import ConeBridge
+from zap.conic.cone_utils import get_standard_conic_problem
+import cvxpy as cp
+import numpy as np
+import scipy.sparse as sp
+import torch
+from zap.admm import ADMMSolver
+
+np.set_printoptions(formatter={"float": "{:6.3f}".format})
+
+
+def main():
+    # Make a problem with two SOC constraints to test on
+    x = cp.Variable(3)
+    y = cp.Variable(4)
+    objective = cp.Minimize(cp.sum_squares(x) + cp.sum_squares(y))
+    constraints = [
+        x[0] >= 0,
+        cp.norm(x[1:]) <= x[0],
+        x[0] + x[1] >= 1,
+        y[0] >= 0,
+        cp.norm(y[1:]) <= y[0],
+        y[0] - y[1] <= 2,
+    ]
+    problem = cp.Problem(objective, constraints)
+    cone_params, data, cones = get_standard_conic_problem(problem, solver=cp.CLARABEL)
+    cone_bridge = ConeBridge(cone_params)
+
+    ### Test ADMM
+    machine = "cpu"
+    dtype = torch.float32
+    admm_devices = [d.torchify(machine=machine, dtype=dtype) for d in cone_bridge.devices]
+    admm = ADMMSolver(
+        machine=machine,
+        dtype=dtype,
+        atol=1e-6,
+        rtol=1e-6,
+        # track_objective=False,
+        # rtol_dual_use_objective=False,
+    )
+    solution_admm, history_admm = admm.solve(
+        cone_bridge.net, admm_devices, cone_bridge.time_horizon
+    )
+    ## End Test ADMM
+
+    outcome = cone_bridge.solve()
+
+    print("helllooooo")
+
+
+if __name__ == "__main__":
+    main()

--- a/cone_tests/soc_debugger_test.py
+++ b/cone_tests/soc_debugger_test.py
@@ -1,5 +1,5 @@
 from zap.conic.cone_bridge import ConeBridge
-from zap.conic.cone_utils import get_standard_conic_problem
+from zap.conic.cone_utils import get_standard_conic_problem, get_conic_solution
 import cvxpy as cp
 import numpy as np
 import scipy.sparse as sp
@@ -42,6 +42,7 @@ def main():
         cone_bridge.net, admm_devices, cone_bridge.time_horizon
     )
     ## End Test ADMM
+    x, s = get_conic_solution(solution_admm, cone_bridge)
 
     outcome = cone_bridge.solve()
 

--- a/cone_tests/soc_tb.py
+++ b/cone_tests/soc_tb.py
@@ -61,12 +61,11 @@ def _(cp, np, sp):
     objective = cp.Minimize(c.T @ x)
 
     prob = cp.Problem(objective, constraints)
-    result = prob.solve()
+    result = prob.solve(solver=cp.CLARABEL)
 
     print("Optimal value:", prob.value)
     print("Optimal x:", x.value)
     print("Optimal s:", s.value)
-
     return A, b, c, constraints, density, m, n, objective, prob, result, s, x
 
 
@@ -145,11 +144,6 @@ def _(soln):
 @app.cell
 def _(cone_params):
     cone_params['A'].toarray().shape
-    return
-
-
-@app.cell
-def _():
     return
 
 

--- a/cone_tests/soc_tb.py
+++ b/cone_tests/soc_tb.py
@@ -1,0 +1,155 @@
+import marimo
+
+__generated_with = "0.11.21"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import cvxpy as cp
+    import numpy as np
+    import time
+    import torch
+    from zap.admm import ADMMSolver
+    from zap.conic.cone_bridge import ConeBridge
+    import scipy.sparse as sp
+    import scs
+    from zap.conic.cone_utils import get_standard_conic_problem
+    return (
+        ADMMSolver,
+        ConeBridge,
+        cp,
+        get_standard_conic_problem,
+        np,
+        scs,
+        sp,
+        time,
+        torch,
+    )
+
+
+@app.cell
+def _(cp):
+    # x = cp.Variable(3)
+    # y = cp.Variable(4)
+    # objective = cp.Minimize(cp.sum_squares(x) + cp.sum_squares(y))
+    # constraints = [
+    #     x[0] >= 0,
+    #     cp.norm(x[1:]) <= x[0],
+    #     x[0] + x[1] >= 1,
+
+    #     y[0] >= 0,
+    #     cp.norm(y[1:]) <= y[0],
+    #     y[0] - y[1] <= 2
+    # ]
+    # prob = cp.Problem(objective, constraints)
+    # result = prob.solve()
+
+    # print("Optimal value:", prob.value)
+    # print("Optimal x:", x.value)
+    # print("Optimal y:", y.value)
+    x = cp.Variable(2)
+    y = cp.Variable(2)
+    z = cp.Variable(2)
+
+    # The objective minimizes the sum of squares of the first entries.
+    objective = cp.Minimize(cp.square(x[0]) + cp.square(y[0]) + cp.square(z[0]))
+
+    # Each SOC constraint enforces that the first entry is at least as large as
+    # the absolute value of the second entry. These form three separate cone blocks.
+    # The linear constraints couple the three variables:
+    #  - x[0] + y[0] + z[0] == 12  forces the sum of the first entries to be 12,
+    #  - x[0] - y[0] == 1          forces x[0] to be 1 greater than y[0],
+    #  - y[0] - z[0] == 1          forces y[0] to be 1 greater than z[0].
+    # With these constraints, we have:
+    #   x[0] = y[0] + 1, and z[0] = y[0] - 1, so:
+    #   (y[0]+1) + y[0] + (y[0]-1) = 3*y[0] = 12  →  y[0] = 4.
+    # Then, x[0] = 5 and z[0] = 3.
+    # Thus the objective evaluates to 5^2 + 4^2 + 3^2 = 25 + 16 + 9 = 50.
+    constraints = [
+        x[0] >= cp.norm(x[1:]),
+        y[0] >= cp.norm(y[1:]),
+        z[0] >= cp.norm(z[1:]),
+        x[0] + y[0] + z[0] == 12,
+        x[0] - y[0] == 1,
+        y[0] - z[0] == 1
+    ]
+
+    # Define and solve the problem
+    prob = cp.Problem(objective, constraints)
+    prob.solve()
+
+    print("Optimal value:", prob.value)
+    print("Optimal x:", x.value)
+    print("Optimal y:", y.value)
+    print("Optimal z:", z.value)
+    return constraints, objective, prob, x, y, z
+
+
+@app.cell
+def _(cp, get_standard_conic_problem, prob):
+    cone_params, data, cones = get_standard_conic_problem(prob, solver=cp.CLARABEL)
+    return cone_params, cones, data
+
+
+@app.cell
+def _(cones, data, scs):
+    ## Solve conic form using SCS
+    soln = scs.solve(data, cones, verbose=False)
+    return (soln,)
+
+
+@app.cell
+def _(cone_params):
+    cone_params
+    return
+
+
+@app.cell
+def _(soln):
+    soln['info']["pobj"]
+    return
+
+
+@app.cell
+def _(soln):
+    soln
+    return
+
+
+app._unparsable_cell(
+    r"""
+    scaled_x = soln[\"x\"][:-1]
+    tau = soln[\"x\"][-1]
+    x_og = scaled_x/tau
+    obj_og = 
+    """,
+    name="_"
+)
+
+
+@app.cell
+def _(cones):
+    cones
+    return
+
+
+@app.cell
+def _(cone_params):
+    cone_params
+    return
+
+
+@app.cell
+def _(cone_params):
+    cone_params['A'].toarray()
+    return
+
+
+@app.cell
+def _():
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/zap/conic/__init__.py
+++ b/zap/conic/__init__.py
@@ -2,4 +2,9 @@
 
 from .cone_bridge import ConeBridge
 from .variable_device import VariableDevice
-from .slack_device import SlackDevice
+from .slack_device import (
+    SlackDevice,
+    ZeroConeSlackDevice,
+    NonNegativeConeSlackDevice,
+    SecondOrderConeSlackDevice,
+)

--- a/zap/conic/cone_utils.py
+++ b/zap/conic/cone_utils.py
@@ -53,7 +53,8 @@ def get_conic_solution(solution, cone_bridge):
 
         # Parse SOC Slacks
         elif type(device) is SecondOrderConeSlackDevice:
-            soc_slacks = np.array([t.item() for t in solution.power[idx]])
+            soc_slacks = np.concatenate([t.flatten().numpy() for t in solution.power[idx]])
+
             s.extend(soc_slacks + device.b_d.flatten())
         # Parse Zero Cone and Nonnegative Slacks
         else:

--- a/zap/conic/slack_device.py
+++ b/zap/conic/slack_device.py
@@ -153,7 +153,7 @@ def _admm_prox_update_soc(power: list[torch.Tensor], b_d: torch.Tensor):
 
     ## Case 1: Already in SOC
     if r <= k:
-        projection = z
+        projection = z  # Really it is z + b_d but then we subtract b_d to get p_d
     ## Case 2: Project to the point (i.e. 0)
     elif k < -r:
         projection = torch.zeros_like(z)


### PR DESCRIPTION
Added:
- Support for problems that have SOC constraints by introducing a SOC slack device
- `cone_bridge.py` now parses and creates SOC slack devices as well 
- `slack_device.py` now has a class SecondOrderConeSlackDevice that implements the SOC constraint for CVXPY and also the prox update
- Extra utility function `get_conic_solution` in `cone_utils.py` that parses out the primal and slack variables from the "power/flow" view used by the devices 

Testing:
- Added an example problem (can see both the Marimo notebook `soc_tb.py` or the python file `soc_debugger_test.py`) that has SOC constraints 
- Both ADMM and CVXPY from Zap objective values on this problem match Clarabel to few digits of accuracy