### PR TITLE
Improve Device Grouping

### DIFF
--- a/zap/conic/cone_bridge.py
+++ b/zap/conic/cone_bridge.py
@@ -12,7 +12,7 @@ from scipy.sparse import csc_matrix, isspmatrix_csc
 
 
 class ConeBridge:
-    def __init__(self, cone_params: dict):
+    def __init__(self, cone_params: dict, grouping_params: dict | None = None):
         self.A = cone_params["A"]
         self.b = cone_params["b"]
         self.c = cone_params["c"]
@@ -23,11 +23,25 @@ class ConeBridge:
 
         if not isspmatrix_csc(self.A):
             self.A = csc_matrix(self.A)
+
+        grouping_params = grouping_params or {}
+        self.variable_grouping_strategy = grouping_params.get(
+            "variable_grouping_strategy", "binned_terminal_groups"
+        )
+        self.slack_grouping_strategy = grouping_params.get(
+            "slack_grouping_strategy", "binned_soc_groups"
+        )
+        self.variable_grouping_bin_edges = grouping_params.get(
+            "variable_grouping_bin_edges", (0, 10, 100, 1000)
+        )
+        self.slack_grouping_bin_edges = grouping_params.get(
+            "slack_grouping_bin_edges", (0, 10, 100, 1000)
+        )
         self._transform()
 
     def _transform(self):
         self._build_network()
-        self._group_variable_devices(strategy="binned_terminal_groups")
+        self._group_variable_devices()
         self._create_variable_devices()
         self._group_slack_devices()
         self._create_slack_devices()
@@ -35,18 +49,16 @@ class ConeBridge:
     def _build_network(self):
         self.net = PowerNetwork(self.A.shape[0])
 
-    def _group_variable_devices(
-        self, strategy="binned_terminal_groups", bin_edges=(0, 10, 100, 1000)
-    ):
+    def _group_variable_devices(self):
         """
         Figure out the appropriate grouping of variable devices based on the number of terminals they have.
         """
-        if strategy == "discrete_terminal_groups":
+        if self.variable_grouping_strategy == "discrete_terminal_groups":
             # Each group consists of devices with exactly the same number of terminals
             self._compute_discrete_terminal_groups()
-        elif strategy == "binned_terminal_groups":
+        elif self.variable_grouping_strategy == "binned_terminal_groups":
             # Each group consists of devices with a number of terminals in the same bin
-            self._compute_binned_terminal_groups(bin_edges)
+            self._compute_binned_terminal_groups(self.variable_grouping_bin_edges)
 
     def _compute_binned_terminal_groups(self, bin_edges):
         """
@@ -58,7 +70,6 @@ class ConeBridge:
         num_terminals_per_device_list = np.diff(self.A.indptr)
         positive_mask = num_terminals_per_device_list > 0
         filtered_counts = num_terminals_per_device_list[positive_mask]
-        # counts = num_terminals_per_device_list[positive_mask]
         device_idxs = np.nonzero(positive_mask)[0]
 
         # Account for upper bound bin (last bin takes everything else)
@@ -137,9 +148,6 @@ class ConeBridge:
 
         num_zero_cone = self.K["z"]
         num_nonneg_cone = self.K["l"]
-        # This is like self.terminal_groups for variable devices
-        self.soc_terminal_groups = np.sort(np.unique(self.K["q"]))
-        self.soc_blocks = self.K["q"]
         self.slack_indices = np.arange(self.b.shape[0])
 
         # Group zero cone slacks
@@ -155,16 +163,66 @@ class ConeBridge:
         )
 
         # Group SOC cone slacks
-        # We are creating a dict like {block_size: [(start, end), ...]}
-        # where each entry corresponds to a block of SOC slacks,
-        # and each tuple in the list is for a block (device) of that size
+        if self.slack_grouping_strategy == "discrete_soc_groups":
+            self._compute_discrete_soc_groups(soc_start=end_nonneg)
+        elif self.slack_grouping_strategy == "binned_soc_groups":
+            self._compute_binned_soc_groups(
+                bin_edges=self.slack_grouping_bin_edges, soc_start=end_nonneg
+            )
+
+    def _compute_binned_soc_groups(self, bin_edges, soc_start):
+        """
+        This function makes a separate group for each set of SOC slacks in the same bin.
+        """
+        self.soc_blocks = self.K["q"]
+        start_idx = soc_start
+        # Account for upper bound bin (last bin takes everything else)
+        edges = np.asarray(bin_edges, dtype=np.int64)
+        edges = np.concatenate(
+            [edges, [np.iinfo(np.int64).max]]
+        )  # Do this instead of np.inf to keep it in int
+
+        soc_bins = [[] for _ in range(len(edges) - 1)]
+
+        # Loop through the blocks of SOC slacks
+        # and assign them to the appropriate bin
+        # We are interested in saving the start and end indices of the blocks,
+        # as well as the size of the block
+        # (which is the number of terminals in the block)
+        for k in self.soc_blocks:
+            start, end = start_idx, start_idx + k
+
+            # Bin assignment
+            bin_idx = np.digitize(k, edges, right=True) - 1
+            soc_bins[bin_idx].append((start, end, k))
+            start_idx = end
+
+        # Remove empty bins
+        self.soc_device_group_map_list = [bin_block for bin_block in soc_bins if bin_block]
+
+    def _compute_discrete_soc_groups(self, soc_start):
+        """
+        This function makes a separate device for each block of SOC slacks.
+        We are creating a dict like {block_size: [(start, end), ...]}
+        where each entry corresponds to a block of SOC slacks,
+        and each tuple in the list is for a block (device) of that size.
+        We convert this into the list of lists of tuples for compatability
+        with the binning approach.
+        """
+        self.soc_device_group_map_list = []
+
+        # This is like self.terminal_groups for variable devices
+        self.soc_terminal_groups = np.sort(np.unique(self.K["q"]))
+        self.soc_blocks = self.K["q"]
         self.soc_block_idxs_dict = {group_size: [] for group_size in self.soc_terminal_groups}
-        soc_start = end_nonneg
         for block_size in self.soc_blocks:
             start = soc_start
             end = soc_start + block_size
-            self.soc_block_idxs_dict[block_size].append((start, end))
+            self.soc_block_idxs_dict[block_size].append((start, end, block_size))
             soc_start += block_size
+        self.soc_device_group_map_list = [
+            self.soc_block_idxs_dict[block_size] for block_size in sorted(self.soc_block_idxs_dict)
+        ]
 
     def _create_slack_devices(self):
         if self.zero_cone_slacks:
@@ -186,16 +244,21 @@ class ConeBridge:
             self.devices.append(nonneg_cone_device)
 
         # Create SOC devices
-        for group_idx, num_terminals_per_device in enumerate(self.soc_terminal_groups):
-            group_slices = self.soc_block_idxs_dict[num_terminals_per_device]
-            b_d_array = np.column_stack([self.b[start:end] for (start, end) in group_slices])
-            terminal_device_array = np.row_stack(
-                [self.slack_indices[start:end] for (start, end) in group_slices]
-            )
+        for bin_blocks in self.soc_device_group_map_list:
+            k_max = max(k for _, _, k in bin_blocks)
+            num_devices = len(bin_blocks)
+
+            b_d_array = np.zeros((k_max, num_devices), dtype=self.b.dtype)
+            terminals = -np.ones((num_devices, k_max), dtype=np.int64)
+            for bin_idx, (start, end, k) in enumerate(bin_blocks):
+                b_d_array[:k, bin_idx] = self.b[start:end]
+                terminals[bin_idx, :k] = self.slack_indices[start:end]
+
             soc_cone_device = SecondOrderConeSlackDevice(
                 num_nodes=self.net.num_nodes,
-                terminals=terminal_device_array,
+                terminals=terminals,
                 b_d=b_d_array,
+                terminals_per_device=np.array([k for _, _, k in bin_blocks]),
             )
             self.devices.append(soc_cone_device)
 

--- a/zap/conic/slack_device.py
+++ b/zap/conic/slack_device.py
@@ -1,9 +1,12 @@
 import torch
 import numpy as np
 import cvxpy as cp
+import scipy.sparse as sp
 from attrs import define
 from typing import List
 from numpy.typing import NDArray
+from functools import cached_property
+from zap.util import infer_machine
 from attrs import field
 from ..devices.abstract import AbstractDevice, make_dynamic
 
@@ -121,6 +124,64 @@ class SecondOrderConeSlackDevice(SlackDevice):
     Slack device that enforces p_d + b_d in the second order cone.
     """
 
+    terminals_per_device: NDArray
+
+    @cached_property
+    def incidence_matrix(self):
+        dimensions = (self.num_nodes, self.num_devices)
+
+        matrices = []
+        for terminal_index in range(self.num_terminals_per_device):
+            if len(self.terminals.shape) == 1:
+                rows = self.terminals
+            else:
+                rows = self.terminals[:, terminal_index]
+
+            # We must ignore the -1 padded rows (these are not real terminals)
+            mask = rows >= 0
+            rows = rows[mask]
+            cols = np.flatnonzero(mask)
+            vals = np.ones(len(rows))
+
+            matrices.append(sp.csc_matrix((vals, (rows, cols)), shape=dimensions))
+
+        return matrices
+
+    def torch_terminals(self, time_horizon, machine=None) -> list[torch.Tensor]:
+        machine = infer_machine() if machine is None else machine
+
+        # Effectively caching manually
+        if (
+            hasattr(self, "_torch_terminals")
+            and self._torch_terminal_time_horizon == time_horizon
+            and self._torch_terminal_machine == machine
+        ):
+            return self._torch_terminals
+
+        tt = self.terminals
+        torch_terminals = []
+        if isinstance(tt, np.ndarray):
+            tt = torch.tensor(tt, device=machine)
+
+        if len(self.terminals.shape) == 1:
+            torch_terminals = [tt.reshape(-1, 1).expand(-1, time_horizon)]
+        else:
+            for i in range(self.num_terminals_per_device):
+                rows = tt[:, i]
+                mask = rows >= 0
+                terminal_vector = (
+                    rows.clone().masked_fill(~mask, 0).reshape(-1, 1)
+                )  # Reshape tensor and replace -1 pads with 0
+                torch_terminals.append(
+                    terminal_vector.expand(-1, time_horizon)
+                )  # This won't do anything when time_horizion is just 1
+
+        self._torch_terminals = torch_terminals
+        self._torch_terminal_time_horizon = time_horizon
+        self._torch_terminal_machine = machine
+
+        return torch_terminals
+
     def equality_constraints(self, _power, _angle, _local_variables, **kwargs):
         return []
 
@@ -136,11 +197,13 @@ class SecondOrderConeSlackDevice(SlackDevice):
         """
         ADMM projection for second order cone:
         """
-        return _admm_prox_update_soc(power, self.b_d)
+        return _admm_prox_update_soc(power, self.b_d, self.terminals_per_device)
 
 
 @torch.jit.script
-def _admm_prox_update_soc(power: list[torch.Tensor], b_d: torch.Tensor):
+def _admm_prox_update_soc(
+    power: list[torch.Tensor], b_d: torch.Tensor, terminals_per_device: torch.Tensor
+):
     """
     ADMM projection for second order cone:
     See overleaf for details. Variable notation follows the Overleaf.
@@ -150,7 +213,15 @@ def _admm_prox_update_soc(power: list[torch.Tensor], b_d: torch.Tensor):
     s = z + b_d
     k = s[0, :]
     u = s[1:, :]
-    r = torch.norm(u, 2, dim=0)
+
+    # Gets which entries of s are valid (i.e. not padded to 0)
+    # Valid is a boolean of the same shape as s, with True for valid entries
+    # and False for padded entries
+    rows = torch.arange(u.shape[0]).unsqueeze(1)
+    valid = rows < (terminals_per_device - 1).unsqueeze(0)
+
+    u_masked = u * valid
+    r = torch.norm(u_masked, 2, dim=0)
 
     proj = torch.zeros_like(s)
 
@@ -166,7 +237,7 @@ def _admm_prox_update_soc(power: list[torch.Tensor], b_d: torch.Tensor):
     # Case 2: Project onto the boundary
     r_boundary = r[boundary_projection_mask]
     k_boundary = k[boundary_projection_mask]
-    u_boundary = u[:, boundary_projection_mask]
+    u_boundary = u_masked[:, boundary_projection_mask]
 
     scale_factor = (r_boundary + k_boundary) / (2 * r_boundary)
     x_star = scale_factor.unsqueeze(0) * u_boundary

--- a/zap/conic/slack_device.py
+++ b/zap/conic/slack_device.py
@@ -217,7 +217,7 @@ def _admm_prox_update_soc(
     # Gets which entries of s are valid (i.e. not padded to 0)
     # Valid is a boolean of the same shape as s, with True for valid entries
     # and False for padded entries
-    rows = torch.arange(u.shape[0]).unsqueeze(1)
+    rows = torch.arange(u.shape[0], device=u.device).unsqueeze(1)
     valid = rows < (terminals_per_device - 1).unsqueeze(0)
 
     u_masked = u * valid

--- a/zap/tests/conic/examples.py
+++ b/zap/tests/conic/examples.py
@@ -2,6 +2,7 @@ import numpy as np
 import cvxpy as cp
 import scipy.sparse as sp
 from zap.conic.cone_utils import get_standard_conic_problem
+from experiments.conic_solve.benchmarks.sparse_cone_benchmark import SparseConeBenchmarkSet
 
 
 def create_simple_problem_zero_nonneg_cones(m=2, n=5, density=0.3, seed=42):
@@ -49,4 +50,13 @@ def create_simple_problem_soc(n=3, m=8, density=0.3, seed=42):
 
     # Convert to conic form
     cone_params, _, _ = get_standard_conic_problem(problem, solver=cp.CLARABEL)
+    return problem, cone_params
+
+
+def create_simple_multi_block_problem_soc():
+    sparse_cone_socp_benchmark = SparseConeBenchmarkSet(num_problems=1, n=15)
+    for i, prob in enumerate(sparse_cone_socp_benchmark):
+        problem = prob
+        cone_params, _, _ = get_standard_conic_problem(problem, solver=cp.CLARABEL)
+
     return problem, cone_params


### PR DESCRIPTION
Added:
- New option to use "binning" strategy for both variable and SOC devices (and is now default behavior)
- Previously, the only grouping happened for devices with the same number of terminals, but now devices with a number of terminals that fall into the same bin (bin edges can be specified) are now grouped as one device
- Previous strategy, referred to as "discrete" grouping, is still supported
- Updates to `VariableDevice` and `SecondOrderConeSlackDevice` to appropriately handle padding, which is used to handle the fact that groups actually consists of devices with differing number of terminals


Testing:
- Added tests in `test_cones.py` that use multi-block SOC constraints
- Verified discrete + binning grouping strategies on all tests in `test_cones.py` 
- Observed solve-time speed up for binning grouping strategy for variable devices by testing Netlib problem with several variable device groups on Sherlock (72.3s --> 26.8s with same accuracy)
