### PR TITLE
Add Ruiz Equilibration 

### DIFF
--- a/experiments/conic_solve/runner.py
+++ b/experiments/conic_solve/runner.py
@@ -180,6 +180,7 @@ def solve_admm(problem, solver_args):
     """
     cone_params, _, _ = get_standard_conic_problem(problem, solver=cp.SCS)
     cone_bridge = ConeBridge(cone_params)
+    print("sigma:", cone_bridge.sigma)
     machine = solver_args.get("machine", "cpu")
     dtype = torch.float32
     admm_devices = [d.torchify(machine=machine, dtype=dtype) for d in cone_bridge.devices]

--- a/experiments/conic_solve/runner.py
+++ b/experiments/conic_solve/runner.py
@@ -5,19 +5,17 @@ import yaml
 import cvxpy as cp
 import sys
 import zap
+import torch
 from copy import deepcopy
+from zap.conic.cone_bridge import ConeBridge
+from zap.admm import ADMMSolver
+from zap.conic.cone_utils import get_standard_conic_problem
 from benchmarks.maros_benchmark import MarosBenchmarkSet
 from benchmarks.netlib_benchmark import NetlibBenchmarkSet
 from benchmarks.lasso_benchmark import LassoBenchmarkSet
 from pathlib import Path
 from benchmarks.sparse_cone_benchmark import SparseConeBenchmarkSet
 from benchmarks.max_flow_benchmark import MaxFlowBenchmarkSet
-from zap.conic.cone_utils import (
-    solve_admm,
-    solve_cuclarabel,
-    solve_cuosqp,
-    solve_cupdlp,
-)
 
 # Reference from .yaml type to get the right class
 BENCHMARK_CLASSES = {
@@ -173,6 +171,50 @@ def run_benchmarks(config: dict):
             )
             all_results.extend(res)
     return all_results
+
+
+# Zap
+def solve_admm(problem, solver_args):
+    """
+    Call conic zap on a CVXPY problem.
+    """
+    cone_params, _, _ = get_standard_conic_problem(problem, solver=cp.SCS)
+    cone_bridge = ConeBridge(cone_params)
+    machine = solver_args.get("machine", "cpu")
+    dtype = torch.float32
+    admm_devices = [d.torchify(machine=machine, dtype=dtype) for d in cone_bridge.devices]
+    admm = ADMMSolver(**solver_args)
+    start_time = time.time()
+    solution_admm, _ = admm.solve(cone_bridge.net, admm_devices, cone_bridge.time_horizon)
+    end_time = time.time()
+    pobj = solution_admm.objective
+    solve_time = end_time - start_time
+
+    return pobj, solve_time
+
+
+# CuClarabel
+def solve_cuclarabel(problem, solver_args):
+    """
+    Call CuClarabel on a CVXPY problem.
+    """
+    raise NotImplementedError
+
+
+# CuOSQP
+def solve_cuosqp(problem, solver_args):
+    """
+    Call CuOSQP on a CVXPY problem.
+    """
+    raise NotImplementedError
+
+
+# CuPDLP
+def solve_cupdlp(problem, solver_args):
+    """
+    Call CuPDLP on a CVXPY problem.
+    """
+    raise NotImplementedError
 
 
 def write_results_to_csv(results, output_file: str):

--- a/zap/conic/cone_bridge.py
+++ b/zap/conic/cone_bridge.py
@@ -9,10 +9,12 @@ from .slack_device import (
     SecondOrderConeSlackDevice,
 )
 from scipy.sparse import csc_matrix, isspmatrix_csc
+from zap.conic.cone_utils import build_symmetric_M, scale_cols_csc, scale_rows_csr
+from copy import deepcopy
 
 
 class ConeBridge:
-    def __init__(self, cone_params: dict, grouping_params: dict | None = None):
+    def __init__(self, cone_params: dict, grouping_params: dict | None = None, ruiz_iters: int = 5):
         self.A = cone_params["A"]
         self.b = cone_params["b"]
         self.c = cone_params["c"]
@@ -20,6 +22,11 @@ class ConeBridge:
         self.net = None
         self.time_horizon = 1
         self.devices = []
+
+        self.ruiz_iters = ruiz_iters
+        self.D_vec = None
+        self.E_vec = None
+        self.sigma = 1
 
         if not isspmatrix_csc(self.A):
             self.A = csc_matrix(self.A)
@@ -40,11 +47,78 @@ class ConeBridge:
         self._transform()
 
     def _transform(self):
+        if self.ruiz_iters > 0:
+            self._equilibrate_ruiz()
         self._build_network()
         self._group_variable_devices()
         self._create_variable_devices()
         self._group_slack_devices()
         self._create_slack_devices()
+
+    def _equilibrate_ruiz(self):
+        """
+        Follows Ruiz Equilibration from SCS papers.
+        Builds the symmetric matrix M = [[P, A.T], [A, 0]]
+        SCS: https://www.cvxgrp.org/scs/algorithm/equilibration.html, https://github.com/cvxgrp/scs
+        """
+        ## TODO: This function needs to change when we add QP support
+        A = deepcopy(self.A)
+        c = deepcopy(self.c)
+        b = deepcopy(self.b)
+
+        m, n = A.shape
+        self.D_vec = np.ones(m)
+        self.E_vec = np.ones(n)
+        num_zero_cone = self.K["z"]
+        num_nonneg_cone = self.K["l"]
+        soc_sizes = self.K.get("q", [])
+        soc_starts = np.cumsum([0] + soc_sizes[:-1]) + (num_zero_cone + num_nonneg_cone)
+
+        for i in range(self.ruiz_iters):
+            # Compute scale factors
+            M = build_symmetric_M(A_csc=A, P=None)
+            col_inf_norms = np.abs(M).max(axis=0).toarray().ravel()
+            delta = np.ones_like(col_inf_norms)
+            delta[col_inf_norms > 0] = 1 / np.sqrt(col_inf_norms[col_inf_norms > 0])
+            delta_cols = delta[:n]
+            delta_rows = delta[n:]
+
+            # Column scaling as part of M equilibration
+            c = delta_cols * c
+            self.E_vec = self.E_vec * delta_cols
+            A = scale_cols_csc(A, delta_cols)
+
+            # Row scaling as part of M equilibration
+            b = delta_rows * b
+            self.D_vec = self.D_vec * delta_rows
+            A_csr = A.tocsr()
+            A_csr = scale_rows_csr(A_csr, delta_rows)
+
+            # Preserve cone membership
+            for s, sz in zip(soc_starts, soc_sizes):
+                block_idxs = slice(s, s + sz)
+                g = np.exp(np.mean(np.log(self.D_vec[block_idxs])))
+                correction_factors = np.ones(m)
+                correction_factors[block_idxs] = g / self.D_vec[block_idxs]
+
+                if not np.allclose(correction_factors, 1):
+                    A_csr = scale_rows_csr(A_csr, correction_factors)
+                    b = b * correction_factors
+                    self.D_vec[block_idxs] = g
+
+            A = A_csr.tocsc()
+
+        # Scaling factor sigma
+        c_inf_norm = np.max(np.abs(c))
+        b_inf_norm = np.max(np.abs(b))
+        self.sigma = 1 / np.max([1, c_inf_norm, b_inf_norm])
+        c = self.sigma * c
+        b = self.sigma * b
+
+        # Update the cone parameters
+        self.A = A
+        self.b = b
+        self.c = c
 
     def _build_network(self):
         self.net = PowerNetwork(self.A.shape[0])

--- a/zap/conic/cone_bridge.py
+++ b/zap/conic/cone_bridge.py
@@ -112,12 +112,23 @@ class ConeBridge:
             # Scaling factor sigma
             # TODO: Change sigma when we support QPs
             c_inf_norm = np.max(np.abs(c))
-            if c_inf_norm == 0:
-                continue
-            sigma = 1 / c_inf_norm
-            sigma = np.clip(sigma, 1e-2 / self.sigma, 1e4 / self.sigma)
-            self.sigma = self.sigma * sigma
-            c = c * sigma
+            sigma_step = 1 / c_inf_norm
+            proposed_sigma = self.sigma * sigma_step
+
+            if proposed_sigma <= 1e-2:
+                sigma_step = 1.0
+            else:
+                proposed_sigma = np.clip(proposed_sigma, None, 1e4)
+                sigma_step = proposed_sigma / self.sigma
+
+            self.sigma *= sigma_step
+            c = c * sigma_step
+            # if c_inf_norm == 0:
+            #     continue
+            # sigma = 1 / c_inf_norm
+            # sigma = np.clip(sigma, 1e-2 / self.sigma, 1e4 / self.sigma)
+            # self.sigma = self.sigma * sigma
+            # c = c * sigma
 
         # Update the cone parameters
         self.A = A

--- a/zap/conic/cone_bridge.py
+++ b/zap/conic/cone_bridge.py
@@ -123,12 +123,6 @@ class ConeBridge:
 
             self.sigma *= sigma_step
             c = c * sigma_step
-            # if c_inf_norm == 0:
-            #     continue
-            # sigma = 1 / c_inf_norm
-            # sigma = np.clip(sigma, 1e-2 / self.sigma, 1e4 / self.sigma)
-            # self.sigma = self.sigma * sigma
-            # c = c * sigma
 
         # Update the cone parameters
         self.A = A

--- a/zap/conic/cone_bridge.py
+++ b/zap/conic/cone_bridge.py
@@ -57,7 +57,7 @@ class ConeBridge:
 
     def _equilibrate_ruiz(self):
         """
-        Follows Ruiz Equilibration from SCS papers.
+        Follows Ruiz Equilibration from Clarabel and OSQP.
         Builds the symmetric matrix M = [[P, A.T], [A, 0]]
         SCS: https://www.cvxgrp.org/scs/algorithm/equilibration.html, https://github.com/cvxgrp/scs
         """

--- a/zap/conic/cone_bridge.py
+++ b/zap/conic/cone_bridge.py
@@ -69,6 +69,7 @@ class ConeBridge:
         m, n = A.shape
         self.D_vec = np.ones(m)
         self.E_vec = np.ones(n)
+        self.sigma = 1
         num_zero_cone = self.K["z"]
         num_nonneg_cone = self.K["l"]
         soc_sizes = self.K.get("q", [])
@@ -108,12 +109,15 @@ class ConeBridge:
 
             A = A_csr.tocsc()
 
-        # Scaling factor sigma
-        c_inf_norm = np.max(np.abs(c))
-        b_inf_norm = np.max(np.abs(b))
-        self.sigma = 1 / np.max([1, c_inf_norm, b_inf_norm])
-        c = self.sigma * c
-        b = self.sigma * b
+            # Scaling factor sigma
+            # TODO: Change sigma when we support QPs
+            c_inf_norm = np.max(np.abs(c))
+            if c_inf_norm == 0:
+                continue
+            sigma = 1 / c_inf_norm
+            sigma = np.clip(sigma, 1e-2 / self.sigma, 1e4 / self.sigma)
+            self.sigma = self.sigma * sigma
+            c = c * sigma
 
         # Update the cone parameters
         self.A = A

--- a/zap/conic/cone_utils.py
+++ b/zap/conic/cone_utils.py
@@ -1,13 +1,11 @@
 import numpy as np
 import cvxpy as cp
+import scipy.sparse as sp
 import torch
-import time
 import json
 from zap.conic.variable_device import VariableDevice
 from zap.conic.slack_device import SecondOrderConeSlackDevice
 from cvxpy.reductions.dcp2cone.dcp2cone import Dcp2Cone
-from zap.conic.cone_bridge import ConeBridge
-from zap.admm import ADMMSolver
 from scipy.sparse.linalg import svds
 
 
@@ -133,49 +131,34 @@ def estimate_condition_number_sparse(A, fallback_tol=1e-12):
         return sigma_max / approx_sigma_min
 
 
-### Calling Custom Solvers (i.e. anything not via CVXPY, basically GPU accelerated solvers) ###
-#######
-
-
-# Zap
-def solve_admm(problem, solver_args):
+### Utilities to Perform Ruiz Equilibration ###
+def build_symmetric_M(A_csc: sp.csc_matrix, P: sp.csc_matrix | None = None) -> sp.csc_matrix:
     """
-    Call conic zap on a CVXPY problem.
+    Build the symmetric matrix M = [[P, A.T], [A, 0]]
     """
-    cone_params, _, _ = get_standard_conic_problem(problem, solver=cp.SCS)
-    cone_bridge = ConeBridge(cone_params)
-    machine = solver_args.get("machine", "cpu")
-    dtype = torch.float32
-    admm_devices = [d.torchify(machine=machine, dtype=dtype) for d in cone_bridge.devices]
-    admm = ADMMSolver(**solver_args)
-    start_time = time.time()
-    solution_admm, _ = admm.solve(cone_bridge.net, admm_devices, cone_bridge.time_horizon)
-    end_time = time.time()
-    pobj = solution_admm.objective
-    solve_time = end_time - start_time
-
-    return pobj, solve_time
+    m, n = A_csc.shape
+    if P is None:
+        P = sp.csc_matrix((n, n))
+    zero_block = sp.csc_matrix((m, m))
+    M = sp.bmat([[P, A_csc.T], [A_csc, zero_block]], format="csc")
+    return M
 
 
-# CuClarabel
-def solve_cuclarabel(problem, solver_args):
+def scale_cols_csc(A_csc: sp.csc_matrix, scale: np.ndarray):
     """
-    Call CuClarabel on a CVXPY problem.
+    This is an efficient way to do A@E where E is a diagonal matrix
+    (i.e. E = diag(scale)).
     """
-    raise NotImplementedError
+    A_csc.data *= np.repeat(scale, np.diff(A_csc.indptr))
+
+    return A_csc
 
 
-# CuOSQP
-def solve_cuosqp(problem, solver_args):
+def scale_rows_csr(A_csr: sp.csr_matrix, scale: np.ndarray):
     """
-    Call CuOSQP on a CVXPY problem.
+    This is an efficient way to do D@A where D is a diagonal matrix.
+    (i.e. D = diag(scale)).
     """
-    raise NotImplementedError
+    A_csr.data *= np.repeat(scale, np.diff(A_csr.indptr))
 
-
-# CuPDLP
-def solve_cupdlp(problem, solver_args):
-    """
-    Call CuPDLP on a CVXPY problem.
-    """
-    raise NotImplementedError
+    return A_csr

--- a/zap/tests/conic/test_cones.py
+++ b/zap/tests/conic/test_cones.py
@@ -6,6 +6,7 @@ import torch
 import scs
 from zap.admm import ADMMSolver
 from zap.conic.cone_bridge import ConeBridge
+from experiments.conic_solve.benchmarks.max_flow_benchmark import MaxFlowBenchmarkSet
 
 from zap.conic.cone_utils import get_standard_conic_problem
 from zap.tests.conic.examples import (
@@ -39,7 +40,7 @@ class TestConeBridge(unittest.TestCase):
         )
         solution_admm, _ = admm.solve(cone_bridge.net, admm_devices, cone_bridge.time_horizon)
         self.assertAlmostEqual(
-            solution_admm.objective / (conic_ruiz_sigma**2),
+            solution_admm.objective / (conic_ruiz_sigma),
             ref_obj,
             delta=TOL,
             msg=f"ADMM objective {solution_admm.objective} differs from reference {ref_obj}",
@@ -54,7 +55,7 @@ class TestConeBridge(unittest.TestCase):
         outcome = cone_bridge.solve()
 
         self.assertAlmostEqual(
-            outcome.problem.value / (conic_ruiz_sigma**2),
+            outcome.problem.value / (conic_ruiz_sigma),
             ref_obj,
             delta=TOL,
             msg=f"CVXPY objective {outcome.problem.value} differs from reference {ref_obj}",
@@ -89,11 +90,11 @@ class TestConeBridge(unittest.TestCase):
             net=cone_bridge.net, devices=cone_admm_devices, time_horizon=cone_bridge.time_horizon
         )
 
-        pct_diff = abs((solution_admm.objective / (conic_ruiz_sigma**2) - ref_obj) / ref_obj)
+        pct_diff = abs((solution_admm.objective / (conic_ruiz_sigma) - ref_obj) / ref_obj)
         self.assertLess(
             pct_diff,
             REL_TOL_PCT,
-            msg=f"ADMM objective {solution_admm.objective} differs from reference objective {ref_obj} by more than {REL_TOL_PCT * 100:.2f}%",
+            msg=f"ADMM objective {solution_admm.objective / (conic_ruiz_sigma)} differs from reference objective {ref_obj} by more than {REL_TOL_PCT * 100:.2f}%",
         )
 
     def test_soc_admm(self):
@@ -114,7 +115,7 @@ class TestConeBridge(unittest.TestCase):
         )
         solution_admm, _ = admm.solve(cone_bridge.net, admm_devices, cone_bridge.time_horizon)
         self.assertAlmostEqual(
-            solution_admm.objective / (conic_ruiz_sigma**2),
+            solution_admm.objective / (conic_ruiz_sigma),
             ref_obj,
             delta=TOL,
             msg=f"ADMM objective {solution_admm.objective} differs from reference {ref_obj}",
@@ -130,7 +131,7 @@ class TestConeBridge(unittest.TestCase):
         outcome = cone_bridge.solve()
 
         self.assertAlmostEqual(
-            outcome.problem.value / (conic_ruiz_sigma**2),
+            outcome.problem.value / (conic_ruiz_sigma),
             ref_obj,
             delta=TOL,
             msg=f"CVXPY objective {outcome.problem.value} differs from reference {ref_obj}",
@@ -154,7 +155,7 @@ class TestConeBridge(unittest.TestCase):
         )
         solution_admm, _ = admm.solve(cone_bridge.net, admm_devices, cone_bridge.time_horizon)
         self.assertAlmostEqual(
-            solution_admm.objective / (conic_ruiz_sigma**2),
+            solution_admm.objective / (conic_ruiz_sigma),
             ref_obj,
             delta=TOL,
             msg=f"ADMM objective {solution_admm.objective} differs from reference {ref_obj}",
@@ -170,7 +171,7 @@ class TestConeBridge(unittest.TestCase):
         outcome = cone_bridge.solve()
 
         self.assertAlmostEqual(
-            outcome.problem.value / (conic_ruiz_sigma**2),
+            outcome.problem.value / (conic_ruiz_sigma),
             ref_obj,
             delta=TOL,
             msg=f"CVXPY objective {outcome.problem.value} differs from reference {ref_obj}",
@@ -181,7 +182,7 @@ class TestConeBridge(unittest.TestCase):
         A_orig = cone_params["A"]
         b_orig = cone_params["b"]
         c_orig = cone_params["c"]
-        cone_bridge = ConeBridge(cone_params, ruiz_iters=25)
+        cone_bridge = ConeBridge(cone_params, ruiz_iters=5)
         D_vec = cone_bridge.D_vec
         E_vec = cone_bridge.E_vec
         c_hat = cone_bridge.c
@@ -190,9 +191,37 @@ class TestConeBridge(unittest.TestCase):
         sigma = cone_bridge.sigma
 
         A_hat_recon = np.diag(D_vec) @ A_orig @ np.diag(E_vec)
-        b_hat_recon = sigma * np.diag(D_vec) @ b_orig
+        b_hat_recon = np.diag(D_vec) @ b_orig
         c_hat_recon = sigma * np.diag(E_vec) @ c_orig
 
         npt.assert_allclose(A_hat, A_hat_recon)
         npt.assert_allclose(b_hat, b_hat_recon)
         npt.assert_allclose(c_hat, c_hat_recon)
+
+    def test_max_flow(self):
+        benchmark = MaxFlowBenchmarkSet(num_problems=1, n=100, base_seed=42)
+        for i, prob in enumerate(benchmark):
+            if i == 0:
+                problem = prob
+                cone_params, _, _ = get_standard_conic_problem(problem, solver=cp.CLARABEL)
+        problem.solve(solver=cp.CLARABEL)
+        ref_obj = problem.value
+
+        cone_bridge = ConeBridge(cone_params, ruiz_iters=5)
+        conic_ruiz_sigma = cone_bridge.sigma
+        machine = "cpu"
+        dtype = torch.float32
+        admm_devices = [d.torchify(machine=machine, dtype=dtype) for d in cone_bridge.devices]
+        admm = ADMMSolver(
+            machine=machine,
+            dtype=dtype,
+            atol=1e-6,
+            rtol=1e-6,
+        )
+        solution_admm, _ = admm.solve(cone_bridge.net, admm_devices, cone_bridge.time_horizon)
+        self.assertAlmostEqual(
+            solution_admm.objective / (conic_ruiz_sigma),
+            ref_obj,
+            delta=TOL,
+            msg=f"CVXPY objective {solution_admm.objective} differs from reference {ref_obj}",
+        )


### PR DESCRIPTION
Added:
- Functionality in `cone_bridge.py` to perform Ruiz equilibration to get scaled problem parameters that can be passed to ADMMSolver with no changes (`def _equilibrate_ruiz()`
- Add some extra utility functions in `cone_utils.py` to help with Ruiz scaling
- Moved around some utility functions from `cone_utils.py` to `runner.py` as part of cleanup 
- Default is 5 iterations of Ruiz but can easily be turned off to skip equilibration steps

Testing:
- Verified that all current test cases still pass with Ruiz equilibration implemented
- Seeing some improvements in convergence for some test cases, others are slightly worse
-  Ran cluster jobs for max_flow, sparse_cone_lp, netlib, and sparse_cone_socp
- Max flow and netlib roughly no effect, sparse_cone_lp improved convergence, sparse_cone_socp slightly worse
- Added a test case just to make sure the transformation is valid 