### PR TITLE
Data Center Device and Planning

### DIFF
--- a/development/datacenter_tb.py
+++ b/development/datacenter_tb.py
@@ -1,0 +1,90 @@
+import marimo
+
+__generated_with = "0.11.21"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    import cvxpy as cp
+    import numpy as np
+    import zap
+    return cp, mo, np, zap
+
+
+@app.cell
+def _(np, zap):
+    net = zap.PowerNetwork(num_nodes=3)
+    T = 3
+    dc_profile = np.array([
+        [0.7, 0.6, 0.8],
+        [0.5, 0.9, 0.4],
+        [0.4, 0.4, 0.6],
+    ])
+    dc_cap0 = np.array([2.0, 1.50, 1.0])
+
+    dcload = zap.DataCenterLoad(
+        num_nodes=net.num_nodes,
+        terminal=np.array([0, 1, 2]),
+        profile=dc_profile,
+        nominal_capacity=dc_cap0,
+        linear_cost=np.array([600.0]),
+    )
+    return T, dc_cap0, dc_profile, dcload, net
+
+
+@app.cell
+def _(T, cp, dcload, net, np, zap):
+    baseload = zap.Load(
+        num_nodes=net.num_nodes,
+        terminal=np.array([2]),
+        load=np.array([[10.0, 15.0, 20.0]]),
+        linear_cost=np.array([500.0]),
+    )
+
+    gens = zap.Generator(
+        num_nodes=net.num_nodes,
+        terminal=np.array([1, 2]),
+        nominal_capacity=np.array([50.0, 25.0]),
+        dynamic_capacity=np.array([[0.3, 0.6, 0.3],
+                                   [1.0, 1.0, 1.0]]),
+        linear_cost=np.array([0.1, 30.0]),
+        emission_rates=np.array([0.0, 500.0]),
+    )
+
+    lines = zap.ACLine(
+        num_nodes=net.num_nodes,
+        source_terminal=np.array([0, 1, 2]),
+        sink_terminal=np.array([1, 2, 0]),
+        nominal_capacity=np.array([10.0, 20.0, 30.0]),
+        susceptance=np.array([1/10.0, 1/20.0, 1/30.0]),
+        capacity=np.ones(3),
+    )
+
+    ground = zap.Ground(num_nodes=net.num_nodes, terminal=np.array([0]))
+    devices = [dcload, baseload, gens, lines, ground]
+
+    outcome = net.dispatch(devices, time_horizon=T, solver=cp.CLARABEL, add_ground=False)
+    return baseload, devices, gens, ground, lines, outcome
+
+
+@app.cell
+def _(dc_cap0, dc_profile, outcome):
+    print("Locational prices ($/MWh):\n", outcome.prices, "\n")
+
+    dc_power = outcome.power[0][0]
+    print("Datacenter withdrawals (MW):\n", dc_power, "\n")
+
+    expected = -dc_profile * dc_cap0.reshape(-1, 1)
+    print("Should equal:\n", expected)
+    return dc_power, expected
+
+
+@app.cell
+def _():
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/zap/__init__.py
+++ b/zap/__init__.py
@@ -3,7 +3,7 @@
 from zap.network import PowerNetwork
 from zap.layer import DispatchLayer
 
-from zap.devices.injector import Injector, Generator, Load
+from zap.devices.injector import Injector, Generator, Load, DataCenterLoad
 from zap.devices.transporter import DCLine, ACLine
 from zap.devices.store import Battery
 from zap.devices.ground import Ground

--- a/zap/devices/__init__.py
+++ b/zap/devices/__init__.py
@@ -3,7 +3,7 @@
 import zap.devices.dual
 
 from zap.devices.abstract import AbstractDevice
-from zap.devices.injector import Injector, Generator, Load
+from zap.devices.injector import Injector, Generator, Load, DataCenterLoad
 from zap.devices.store import Battery
 from zap.devices.transporter import DCLine, ACLine
 from zap.devices.ground import Ground

--- a/zap/devices/injector.py
+++ b/zap/devices/injector.py
@@ -344,6 +344,25 @@ class Load(AbstractInjector):
         return dev
 
 
+@define(kw_only=True, slots=False)
+class DataCenterLoad(AbstractInjector):
+    """Currently only represents fixed‑profile load whose size (nominal_capacity) is optimized."""
+
+    profile: NDArray = field(converter=make_dynamic)
+    linear_cost: NDArray = field(converter=make_dynamic)
+    quadratic_cost: Optional[NDArray] = field(default=None, converter=make_dynamic)
+    nominal_capacity: NDArray = field(converter=make_dynamic)
+    capital_cost: Optional[NDArray] = field(default=None, converter=make_dynamic)
+
+    @property
+    def min_power(self):
+        return -self.profile
+
+    @property
+    def max_power(self):
+        return 0.0 * self.profile
+
+
 @torch.jit.script
 def _admm_prox_update(power: list[torch.Tensor], rho: float, lin_cost, quad_cost, pmin, pmax):
     # Problem is

--- a/zap/planning/__init__.py
+++ b/zap/planning/__init__.py
@@ -11,3 +11,5 @@ from zap.planning.operation_objectives import (
     EmissionsObjective,
     MultiObjective,
 )
+
+from zap.planning.projection import SimplexBudgetProjection

--- a/zap/planning/problem_abstract.py
+++ b/zap/planning/problem_abstract.py
@@ -23,12 +23,14 @@ class AbstractPlanningProblem:
         layer: DispatchLayer,
         lower_bounds: dict = None,
         upper_bounds: dict = None,
+        extra_projections: dict[str, callable] = None,
     ):
         self.operation_objective = operation_objective
         self.investment_objective = investment_objective
         self.layer = layer
         self.lower_bounds = lower_bounds
         self.upper_bounds = upper_bounds
+        self.extra_projections = extra_projections
 
         if self.lower_bounds is None:
             self.lower_bounds = {
@@ -233,6 +235,11 @@ class AbstractPlanningProblem:
             state[param] = self.la.clip(
                 state[param], self.lower_bounds[param], self.upper_bounds[param]
             )
+        # Perform extra projections (like simplex budget projection)
+        proj = getattr(self, "extra_projections", {}).get(param)
+        if proj is not None:
+            state[param] = proj(state[param])
+            return state
         return state
 
     def get_state(self):

--- a/zap/planning/projection.py
+++ b/zap/planning/projection.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+
+class Projection:
+    def __call__(self, x):
+        raise NotImplementedError
+
+
+class SimplexBudgetProjection(Projection):
+    def __init__(self, budget, strict=True):
+        self.budget = budget
+        self.strict = strict
+
+    def __call__(self, x):
+        """
+        Simplex projection algorithm from Duchi et al. (2008)
+        https://stanford.edu/~jduchi/projects/DuchiShSiCh08.pdf
+        """
+        x = np.maximum(x, 0.0)
+        s = x.sum()
+        if (self.strict and abs(s - self.budget) < 1e-12) or (not self.strict and s <= self.budget):
+            return x
+        u = np.sort(x)[::-1]
+        cssv = np.cumsum(u)
+        rho = np.nonzero(u * np.arange(1, len(u) + 1) > (cssv - self.budget))[0][-1]
+        theta = (cssv[rho] - self.budget) / (rho + 1)
+        return np.maximum(x - theta, 0.0)


### PR DESCRIPTION
Added:
- New DataCenterLoad device that supports a fixed profile that is scaled by nominal capacity
- Simplex projection to enforce capacity coupling constraints between data centers

Testing:
- Marimo notebook for experimentation and debugging
