### PR TITLE
Natively Support Conic QPs

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,6 +20,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      # Install system dependencies
+      - name: Install SuiteSparse
+        run: sudo apt-get update && sudo apt-get install -y libsuitesparse-dev
       - name: Setup Poetry
         uses: snok/install-poetry@v1
       - name: Install Dependencies

--- a/experiments/conic_solve/launch.py
+++ b/experiments/conic_solve/launch.py
@@ -41,6 +41,13 @@ for i, config in enumerate(config_list):
 {gpu_line}
 #SBATCH --time={system["runtime"]}
 
+module load cuda/12.2.0
+module load openblas/0.3.20
+module load suitesparse/7.4.0
+
+LD_LIBRARY_PATH=$(echo $LD_LIBRARY_PATH | tr ':' '\n' | grep -v "$HOME/.local/cuda-stubs" | paste -sd ':' -)
+export LD_LIBRARY_PATH
+
 poetry run python3 -u experiments/conic_solve/runner.py {config_path} {i}
 """
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -3838,9 +3838,10 @@ files = [
 name = "scikit-sparse"
 version = "0.4.16"
 description = "Scikit sparse matrix package"
-optional = false
+optional = true
 python-versions = ">=3.6"
 groups = ["main"]
+markers = "extra == \"cholmod\""
 files = [
     {file = "scikit_sparse-0.4.16.tar.gz", hash = "sha256:3baf49ac98ae8cc4357005af49a0df93a6a53f4e61708705da2942ea4fa61a56"},
 ]
@@ -5002,10 +5003,11 @@ test = ["big-O", "importlib-resources ; python_version < \"3.9\"", "jaraco.funct
 type = ["pytest-mypy"]
 
 [extras]
+cholmod = ["scikit-sparse"]
 mkl = ["sparse-dot-mkl"]
 pypsa = ["pypsa"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "be744a914dadbb301f372c2c9ca6277e7bd5c608d75a57449f05186edb6db765"
+content-hash = "da2252ffdfeaa9cd669a639cde21be3ae5dd5367171815f887de25c85f48daf0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3835,6 +3835,21 @@ files = [
 ]
 
 [[package]]
+name = "scikit-sparse"
+version = "0.4.16"
+description = "Scikit sparse matrix package"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "scikit_sparse-0.4.16.tar.gz", hash = "sha256:3baf49ac98ae8cc4357005af49a0df93a6a53f4e61708705da2942ea4fa61a56"},
+]
+
+[package.dependencies]
+numpy = ">=1.13.3"
+scipy = ">=0.19"
+
+[[package]]
 name = "scipy"
 version = "1.14.1"
 description = "Fundamental algorithms for scientific computing in Python"
@@ -4993,4 +5008,4 @@ pypsa = ["pypsa"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "75e14eef7e8c37d1f76c985256f4c534db2d00eca068e15e9ff1a72767946210"
+content-hash = "be744a914dadbb301f372c2c9ca6277e7bd5c608d75a57449f05186edb6db765"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ attrs = "^24.2.0"
 marimo = "^0.11.21"
 cvxpy = "^1.6.4"
 ortools = "9.11.4210"
+scikit-sparse = "^0.4.16"
 
 [tool.poetry.extras]
 pypsa = ["pypsa"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,12 @@ attrs = "^24.2.0"
 marimo = "^0.11.21"
 cvxpy = "^1.6.4"
 ortools = "9.11.4210"
-scikit-sparse = "^0.4.16"
+scikit-sparse = { version = "^0.4.16", optional = true }
 
 [tool.poetry.extras]
 pypsa = ["pypsa"]
 mkl = ["sparse-dot-mkl"]
+cholmod = ["scikit-sparse"]
 
 [tool.poetry.group.dev.dependencies]
 matplotlib = "^3.9.2"

--- a/zap/conic/cone_bridge.py
+++ b/zap/conic/cone_bridge.py
@@ -16,7 +16,6 @@ from zap.conic.cone_utils import (
     build_symmetric_M,
     scale_cols_csc,
     scale_rows_csr,
-    mean_column_inf_norm,
 )
 from copy import deepcopy
 

--- a/zap/conic/quadratic_device.py
+++ b/zap/conic/quadratic_device.py
@@ -1,0 +1,43 @@
+import torch
+import numpy as np
+import cvxpy as cp
+from attrs import define
+from typing import List
+from numpy.typing import NDArray
+from ..devices.abstract import AbstractDevice
+
+
+@define(kw_only=True, slots=False)
+class QuadraticDevice(AbstractDevice):
+    """
+    Represents a block of single terminal quadratic devices.
+    """
+
+    num_nodes: int
+    terminals: NDArray
+
+    @property
+    def time_horizon(self) -> int:
+        return 1
+
+    def model_local_variables(self, time_horizon: int) -> List[cp.Variable]:
+        return None
+
+    def operation_cost(self, power, _angle, local_variables, la=np, **kwargs):
+        return 0.5 * la.sum(power[0] ** 2)
+
+    def equality_constraints(self, _power, _angle, _local_variables, **kwargs):
+        return []
+
+    def inequality_constraints(self, power, _angle, _local_variables, **kwargs):
+        return []
+
+    def admm_prox_update(self, rho_power, _rho_angle, power, _angle, **kwargs):
+        return _admm_prox_update(power, rho_power)
+
+
+@torch.jit.script
+def _admm_prox_update(power: list[torch.Tensor], rho: float):
+    scaling = rho / (1 + rho)
+    y_star = power[0] * scaling
+    return [y_star], None, None

--- a/zap/tests/conic/examples.py
+++ b/zap/tests/conic/examples.py
@@ -5,7 +5,7 @@ from zap.conic.cone_utils import get_standard_conic_problem
 from experiments.conic_solve.benchmarks.sparse_cone_benchmark import SparseConeBenchmarkSet
 
 
-def create_simple_problem_zero_nonneg_cones(m=2, n=5, density=0.3, seed=42):
+def create_simple_problem_zero_nonneg_cones(m=2, n=5, density=0.3, seed=42, quad_obj=False):
     """
     This problem has only zero and nonnegative cone constraints.
     """
@@ -17,7 +17,12 @@ def create_simple_problem_zero_nonneg_cones(m=2, n=5, density=0.3, seed=42):
     x = cp.Variable(n)
     s = cp.Variable(m)
     constraints = [A @ x + s == b, s >= 0, x >= -5, x <= 5]
-    objective = cp.Minimize(c.T @ x)
+    if quad_obj:
+        L = np.random.randn(n, n)
+        P = L.T @ L
+        objective = cp.Minimize(0.5 * cp.quad_form(x, P) + c.T @ x)
+    else:
+        objective = cp.Minimize(c.T @ x)
     problem = cp.Problem(objective, constraints)
 
     # Convert to conic form

--- a/zap/tests/conic/test_cones.py
+++ b/zap/tests/conic/test_cones.py
@@ -232,7 +232,7 @@ class TestConeBridge(unittest.TestCase):
     def test_netlib(self):
         benchmark = NetlibBenchmarkSet(data_dir="data/conic_benchmarks/netlib")
         for i, prob in enumerate(benchmark):
-            if i == 2:
+            if i == 0:
                 problem = prob
                 cone_params, _, _ = get_standard_conic_problem(problem, solver=cp.CLARABEL)
         problem.solve(solver=cp.CLARABEL)
@@ -250,11 +250,11 @@ class TestConeBridge(unittest.TestCase):
             rtol=1e-6,
         )
         solution_admm, _ = admm.solve(cone_bridge.net, admm_devices, cone_bridge.time_horizon)
-        self.assertAlmostEqual(
-            solution_admm.objective / (conic_ruiz_sigma),
-            ref_obj,
-            delta=TOL,
-            msg=f"CVXPY objective {solution_admm.objective} differs from reference {ref_obj}",
+        pct_diff = abs((solution_admm.objective / (conic_ruiz_sigma) - ref_obj) / ref_obj)
+        self.assertLess(
+            pct_diff,
+            REL_TOL_PCT,
+            msg=f"ADMM objective {solution_admm.objective / (conic_ruiz_sigma)} differs from reference objective {ref_obj} by more than {REL_TOL_PCT * 100:.2f}%",
         )
 
     def test_sparse_cone_lp(self):
@@ -266,7 +266,7 @@ class TestConeBridge(unittest.TestCase):
         problem.solve(solver=cp.CLARABEL)
         ref_obj = problem.value
 
-        cone_bridge = ConeBridge(cone_params, ruiz_iters=0)
+        cone_bridge = ConeBridge(cone_params, ruiz_iters=5)
         conic_ruiz_sigma = cone_bridge.sigma
         machine = "cpu"
         dtype = torch.float32

--- a/zap/tests/conic/test_cones.py
+++ b/zap/tests/conic/test_cones.py
@@ -238,7 +238,7 @@ class TestConeBridge(unittest.TestCase):
         problem.solve(solver=cp.CLARABEL)
         ref_obj = problem.value
 
-        cone_bridge = ConeBridge(cone_params, ruiz_iters=0)
+        cone_bridge = ConeBridge(cone_params, ruiz_iters=5)
         conic_ruiz_sigma = cone_bridge.sigma
         machine = "cpu"
         dtype = torch.float32
@@ -290,7 +290,7 @@ class TestConeBridge(unittest.TestCase):
         problem.solve(solver=cp.CLARABEL)
         ref_obj = problem.value
 
-        cone_bridge = ConeBridge(cone_params, ruiz_iters=0)
+        cone_bridge = ConeBridge(cone_params, ruiz_iters=5)
         conic_ruiz_sigma = cone_bridge.sigma
         machine = "cpu"
         dtype = torch.float32
@@ -314,7 +314,7 @@ class TestConeBridge(unittest.TestCase):
         problem.solve(solver=cp.CLARABEL)
         ref_obj = problem.value
 
-        cone_bridge = ConeBridge(cone_params, ruiz_iters=0)
+        cone_bridge = ConeBridge(cone_params, ruiz_iters=5)
         conic_ruiz_sigma = cone_bridge.sigma
         outcome = cone_bridge.solve()
 

--- a/zap/tests/conic/test_cones.py
+++ b/zap/tests/conic/test_cones.py
@@ -11,7 +11,7 @@ from experiments.conic_solve.benchmarks.netlib_benchmark import NetlibBenchmarkS
 from experiments.conic_solve.benchmarks.sparse_cone_benchmark import SparseConeBenchmarkSet
 
 
-from zap.conic.cone_utils import get_standard_conic_problem
+from zap.conic.cone_utils import get_standard_conic_problem, get_conic_solution
 from zap.tests.conic.examples import (
     create_simple_problem_zero_nonneg_cones,
     create_simple_problem_soc,
@@ -204,7 +204,7 @@ class TestConeBridge(unittest.TestCase):
     def test_max_flow(self):
         benchmark = MaxFlowBenchmarkSet(num_problems=1, n=100, base_seed=42)
         for i, prob in enumerate(benchmark):
-            if i == 2:
+            if i == 0:
                 problem = prob
                 cone_params, _, _ = get_standard_conic_problem(problem, solver=cp.CLARABEL)
         problem.solve(solver=cp.CLARABEL)
@@ -238,7 +238,7 @@ class TestConeBridge(unittest.TestCase):
         problem.solve(solver=cp.CLARABEL)
         ref_obj = problem.value
 
-        cone_bridge = ConeBridge(cone_params, ruiz_iters=5)
+        cone_bridge = ConeBridge(cone_params, ruiz_iters=0)
         conic_ruiz_sigma = cone_bridge.sigma
         machine = "cpu"
         dtype = torch.float32
@@ -266,7 +266,7 @@ class TestConeBridge(unittest.TestCase):
         problem.solve(solver=cp.CLARABEL)
         ref_obj = problem.value
 
-        cone_bridge = ConeBridge(cone_params, ruiz_iters=5)
+        cone_bridge = ConeBridge(cone_params, ruiz_iters=0)
         conic_ruiz_sigma = cone_bridge.sigma
         machine = "cpu"
         dtype = torch.float32
@@ -283,4 +283,44 @@ class TestConeBridge(unittest.TestCase):
             ref_obj,
             delta=TOL,
             msg=f"CVXPY objective {solution_admm.objective} differs from reference {ref_obj}",
+        )
+
+    def test_conic_qp_admm(self):
+        problem, cone_params = create_simple_problem_zero_nonneg_cones(quad_obj=True)
+        problem.solve(solver=cp.CLARABEL)
+        ref_obj = problem.value
+
+        cone_bridge = ConeBridge(cone_params, ruiz_iters=0)
+        conic_ruiz_sigma = cone_bridge.sigma
+        machine = "cpu"
+        dtype = torch.float32
+        admm_devices = [d.torchify(machine=machine, dtype=dtype) for d in cone_bridge.devices]
+        admm = ADMMSolver(
+            machine=machine,
+            dtype=dtype,
+            atol=1e-6,
+            rtol=1e-6,
+        )
+        solution_admm, _ = admm.solve(cone_bridge.net, admm_devices, cone_bridge.time_horizon)
+        self.assertAlmostEqual(
+            solution_admm.objective / (conic_ruiz_sigma),
+            ref_obj,
+            delta=TOL,
+            msg=f"ADMM objective {solution_admm.objective} differs from reference {ref_obj}",
+        )
+
+    def test_conic_qp_cvxpy(self):
+        problem, cone_params = create_simple_problem_zero_nonneg_cones(quad_obj=True)
+        problem.solve(solver=cp.CLARABEL)
+        ref_obj = problem.value
+
+        cone_bridge = ConeBridge(cone_params, ruiz_iters=0)
+        conic_ruiz_sigma = cone_bridge.sigma
+        outcome = cone_bridge.solve()
+
+        self.assertAlmostEqual(
+            outcome.problem.value / (conic_ruiz_sigma),
+            ref_obj,
+            delta=TOL,
+            msg=f"CVXPY objective {outcome.problem.value} differs from reference {ref_obj}",
         )


### PR DESCRIPTION
Added:
- New function in ConeBridge `_factorize_P()` that permutes P and does LDLT factorization. Forms stacked matrix G that gets used instead of A for variable devices
- New `scikit-sparse` dependency to use CHOLMOD for LDLT
- Modification to `launch`.py as part of supporting CHOLMOD dependecy on Sherlock
- New device type `QuadraticDevice` that that handles quadratic cost terms 
- Modified Ruiz equilibration procedure to also consider P from the quadratic cost

Testing:
- Verified that procedure works with new test case `test_conic_qp_`
- Verified that all prior test cases still pass
- Verified working on GPU on Sherlock (lasso small test case now solves faster and much more accurately than before)